### PR TITLE
Fix command in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ ics 是最流行的日历文件之一，受到几乎所有日历软件的支持�
 ```
 sudo apt-get install tesseract-ocr nodejs
 sudo apt-get install python3-pip libapache2-mod-wsgi-py3 python-dev
-pip3 install flask lxml request pillow pyexecjs pytesseract
+pip3 install flask lxml requests pillow pyexecjs
+pip3 install pytesseract
 ```
 
 如果运行的时候还缺了什么，请 pip / pip3 上。


### PR DESCRIPTION
- Pip package `request` does not exist. Maybe `requests`?

- `pip3 install pillow pytesseract` may cause error, because pytesseract requires pillow:

``` plain
ERROR: Command errored out with exit status 1:
...
File "/tmp/pip-install-2k6127uv/pytesseract/pytesseract/pytesseract.py", line 28, in <module>
        import Image
    ModuleNotFoundError: No module named 'Image'
...
```

Installing `pillow` and `pytesseract` separately works.

This issue exist in `Python 3.8.10` + `pip 20.0.2`, and doesn't exist in `Python 3.10.1` + `pip 21.2.4`.

Using a **CLEAN** docker container.